### PR TITLE
Add support for SUSE 11

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,9 @@ platforms:
     driver:
       box: opensuse-12.2-x86_64
       box_url: http://sourceforge.net/projects/opensusevagrant/files/12.2/opensuse-12.2-32.box/download
+  - name: sles11sp3
+    driver:
+      box: suse/sles11sp3
 suites:
   - name: default
     run_list:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ryan.mango.larson@gmail.com'
 license          'MIT'
 description      'Ensures a good source of entropy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.1.0'
 
 depends 'yum-epel', '<= 0.6.0'
 depends 'apt', '>= 0.0.0'
@@ -16,4 +16,4 @@ supports 'oracle', '>= 5.0'
 # We claim rhel support because we work on CentOS but we don't have the ability to test on rhel
 supports 'redhat', '>= 5.0'
 supports 'fedora', '>= 18.0'
-supports 'suse', '>= 12.2'
+supports 'suse', '>= 11.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,11 @@ end
 
 def install_suse
   package 'haveged'
-  start_systemd_haveged_service
+  if node['platform_version'].to_i < 12
+    start_sys_v_haveged_service
+  else
+    start_systemd_haveged_service
+  end
 end
 
 if node['platform_family'] == 'rhel'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -92,8 +92,13 @@ describe 'entropy::default' do
     suse_family_platforms.each do |suse_platform|
       context "on #{suse_platform[:platform]} #{suse_platform[:version]}" do
         let(:platform) { suse_platform }
+        major_version = suse_platform[:version].split('.')[0].to_i
         it { is_expected.to install_package('haveged') }
-        it { is_expected.to start_service('haveged.service') }
+        if major_version < 12
+          it { is_expected.to start_service('haveged') }
+        else
+          it { is_expected.to start_service('haveged.service') }
+        end
       end
     end
   end


### PR DESCRIPTION
SUSE 11 uses Sys V init instead of systemd, this PR makes the default recipe work on that platform.

Added chefspec and test kitchen tests for it. :)
