### PR TITLE
Update yum-epel to newer version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ bin/*
 .kitchen/
 .kitchen.local.yml
 .idea
+
+vendor/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  require_chef_omnibus: 12.3.0
+  require_chef_omnibus: 12.13.37
   name: vagrant
 
 provisioner:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'ryan.mango.larson@gmail.com'
 license          'MIT'
 description      'Ensures a good source of entropy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 
-depends 'yum-epel', '<= 0.6.0'
+depends 'yum-epel', '> 2.0.0'
 depends 'apt', '>= 0.0.0'
 
 supports 'ubuntu', '>= 12.04'


### PR DESCRIPTION
@rylarson I was adding a cookbook that needed a newer version of yum-epel so I forked this and updated it. Seems like it passes testing still.

Note - I did need to updated chef_omnibus in the kitchen file in order for the new epel cookbook to work.